### PR TITLE
rootProject名変更

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-rootProject.name = 'lineworks_bot_sample'
+rootProject.name = 'lineworks-sample'


### PR DESCRIPTION
## 変更箇所
[setting.gradle](https://github.com/solxyz-jsn/lineworks-sample/pull/1/files#diff-7f825392aa37acd1cee0c2e7b9bb7366ad6eac64f3e6cdd816e156bcb69d30de)

 rootProject名を`lineworks-sample`に変更

## 変更理由

アカデミー用記事には「プロジェクト名が`lineworks-sample`として表示される」と記載しているが、サンプルコード動作確認時のVisual Studio Code（バージョン1.85）ではrootProject.nameに設定している値がプロジェクト名として表示されることを確認したため（スクリーンショット参照）

## スクリーンショット

Visual Studio Code（バージョン1.85、1.84）で表示確認

### rootProject名変更前

![画像1](https://github.com/solxyz-jsn/lineworks-sample/assets/154206918/f1dd8a0d-cdc7-4fe3-a133-3652867fea12)

### rootProject名変更後

![画像1-2](https://github.com/solxyz-jsn/lineworks-sample/assets/154206918/df1786d8-022d-4565-8a45-e9067c2be124)

